### PR TITLE
Added provenance metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ezomero>=1.0.0
 ome-types>=0.2.10
+setuptools>=58.0.0

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -32,7 +32,7 @@ def create_datasets(dss, conn):
     return ds_map
 
 
-def create_annotations(ans, conn):
+def create_annotations(ans, conn, hash):
     ann_map = {}
     for an in ans:
         if isinstance(an, TagAnnotation):
@@ -48,6 +48,8 @@ def create_annotations(ans, conn):
             key_value_data = []
             for v in an.value.m:
                 key_value_data.append([v.k, v.value])
+            if int(an.id.split(":")[-1]) < 0:
+                key_value_data.append(['zip_file_md5', hash])
             map_ann.setValue(key_value_data)
             map_ann.save()
             ann_map[an.id] = map_ann.getId()
@@ -181,10 +183,10 @@ def link_annotations(ome, proj_map, ds_map, img_map, ann_map, conn):
     return
 
 
-def populate_omero(ome, img_map, conn):
+def populate_omero(ome, img_map, conn, hash):
     proj_map = create_projects(ome.projects, conn)
     ds_map = create_datasets(ome.datasets, conn)
-    ann_map = create_annotations(ome.structured_annotations, conn)
+    ann_map = create_annotations(ome.structured_annotations, conn, hash)
     create_rois(ome.rois, ome.images, img_map, conn)
     link_datasets(ome, proj_map, ds_map, conn)
     link_images(ome, ds_map, img_map, conn)

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -182,8 +182,6 @@ def link_annotations(ome, proj_map, ds_map, img_map, ann_map, conn):
 
 
 def populate_omero(ome, img_map, conn):
-    print(img_map)
-    print(ome)
     proj_map = create_projects(ome.projects, conn)
     ds_map = create_datasets(ome.datasets, conn)
     ann_map = create_annotations(ome.structured_annotations, conn)

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -182,6 +182,8 @@ def link_annotations(ome, proj_map, ds_map, img_map, ann_map, conn):
 
 
 def populate_omero(ome, img_map, conn):
+    print(img_map)
+    print(ome)
     proj_map = create_projects(ome.projects, conn)
     ds_map = create_datasets(ome.datasets, conn)
     ann_map = create_annotations(ome.structured_annotations, conn)

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -240,7 +240,7 @@ def create_provenance_metadata(id, hostname):
     software = "omero-cli-transfer"
     version = pkg_resources.get_distribution(software).version
     date_time = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
-    md_dict = {'image_id': id, 'origin_hostname': hostname,
+    md_dict = {'origin_image_id': id, 'origin_hostname': hostname,
                'packing_timestamp': date_time,
                'software': software, 'version': version}
     ns = 'openmicroscopy.org/cli/transfer'

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -254,7 +254,6 @@ def create_provenance_metadata(id, hostname):
     kv, ref = create_kv_and_ref(id=id,
                                 namespace=ns,
                                 value=Map(m=mmap))
-    print(kv, ref)
     return kv, ref
 
 

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -239,7 +239,7 @@ def create_filepath_annotations(repo, id, conn):
 def create_provenance_metadata(id, hostname):
     software = "omero-cli-transfer"
     version = pkg_resources.get_distribution(software).version
-    date_time = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
+    date_time = datetime.now().strftime("%d/%m/%Y, %H:%M:%S")
     md_dict = {'origin_image_id': id, 'origin_hostname': hostname,
                'packing_timestamp': date_time,
                'software': software, 'version': version}

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -246,7 +246,7 @@ def create_provenance_metadata(id, hostname):
     ns = 'openmicroscopy.org/cli/transfer'
     id = (-1) * uuid4().int
     mmap = []
-    for _key, _value in md_dict:
+    for _key, _value in md_dict.items():
         if _value:
             mmap.append(M(k=_key, value=str(_value)))
         else:

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -13,6 +13,7 @@ import pkg_resources
 import ezomero
 import os
 from uuid import uuid4
+from datetime import datetime
 
 
 def create_proj_and_ref(**kwargs):
@@ -238,7 +239,11 @@ def create_filepath_annotations(repo, id, conn):
 def create_provenance_metadata(id, hostname):
     software = "omero-cli-transfer"
     version = pkg_resources.get_distribution(software).version
-    print(hostname)
+    date_time = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
+    md_dict = {'image_id': id, 'origin_hostaname': hostname,
+               'packing_timestamp': date_time,
+               'software': software, 'version': version}
+    print(md_dict)
 
 
 def populate_roi(obj, roi_obj, ome, conn):

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -235,11 +235,12 @@ class TransferControl(GraphControl):
                 print("comment with negative ID", ann)
                 img_map[ann.value].append(int(ann.namespace.split(":")[-1]))
                 filelist.append(ann.value.split('/./')[-1])
-                print("updated filelist: ", filelist)
+                print("updated img_map: ", img_map)
                 newome.structured_annotations.remove(ann)
         for i in newome.images:
             print("checking image for ann refs: ", i.id)
             for ref in i.annotation_ref:
+                print(ref.id, ann.id)
                 if ref.id == ann.id:
                     i.annotation_ref.remove(ref)
                     print("new image: ", i)

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -233,19 +233,14 @@ class TransferControl(GraphControl):
         for ann in ome.structured_annotations:
             if int(ann.id.split(":")[-1]) < 0 \
                and type(ann) == CommentAnnotation:
-                print("comment with negative ID", ann)
                 map_ref_ids.append(ann.id)
                 img_map[ann.value].append(int(ann.namespace.split(":")[-1]))
                 filelist.append(ann.value.split('/./')[-1])
-                print("updated img_map: ", img_map)
                 newome.structured_annotations.remove(ann)
         for i in newome.images:
-            print("checking image for ann refs: ", i.id)
             for ref in i.annotation_ref:
-                print(ref.id, map_ref_ids)
                 if ref.id in map_ref_ids:
                     i.annotation_ref.remove(ref)
-                    print("new image: ", i)
         filelist = list(set(filelist))
         img_map = {x: sorted(img_map[x]) for x in img_map.keys()}
         return newome, img_map, filelist

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -10,6 +10,7 @@
 from pathlib import Path
 import sys
 import os
+from ome_types import CommentAnnotation
 from functools import wraps
 import shutil
 from collections import defaultdict
@@ -226,14 +227,15 @@ class TransferControl(GraphControl):
         img_map = defaultdict(list)
         filelist = []
         for ann in ome.structured_annotations:
-            if int(ann.id.split(":")[-1]) < 0:
+            if int(ann.id.split(":")[-1]) < 0 \
+               and type(ann) == CommentAnnotation:
                 img_map[ann.value].append(int(ann.namespace.split(":")[-1]))
                 filelist.append(ann.value.split('/./')[-1])
-        ome.structured_annotations = [x for x in ome.structured_annotations
-                                      if int(x.id.split(":")[-1]) > 0]
+                ome.structured_annotations.remove(ann)
         for i in ome.images:
-            i.annotation_ref = [x for x in i.annotation_ref
-                                if int(x.id.split(":")[-1]) > 0]
+            for ref in i.annotation_ref:
+                if ref.id == ann.id:
+                    i.annotation_ref.remove(ref)
         filelist = list(set(filelist))
         img_map = {x: sorted(img_map[x]) for x in img_map.keys()}
         return img_map, filelist

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -84,7 +84,8 @@ def gateway_required(func):
     def _wrapper(self, *args, **kwargs):
         self.client = self.ctx.conn(*args)
         self.gateway = BlitzGateway(client_obj=self.client)
-        self.hostname = self.client.getRouter(self.client.getCommunicator())
+        router = self.client.getRouter(self.client.getCommunicator())
+        self.hostname = router.split('-h ')[-1].split()[0]
         try:
             return func(self, *args, **kwargs)
         finally:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -10,7 +10,7 @@
 from pathlib import Path
 import sys
 import os
-from ome_types import CommentAnnotation
+from ome_types.model import CommentAnnotation
 from functools import wraps
 import shutil
 from collections import defaultdict

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -84,7 +84,7 @@ def gateway_required(func):
     def _wrapper(self, *args, **kwargs):
         self.client = self.ctx.conn(*args)
         self.gateway = BlitzGateway(client_obj=self.client)
-
+        self.hostname = self.client.getRouter(self.client.getCommunicator())
         try:
             return func(self, *args, **kwargs)
         finally:
@@ -174,7 +174,7 @@ class TransferControl(GraphControl):
         xml_fp = str(Path(folder) / "transfer.xml")
         repo = self._get_path_to_repo()[0]
         path_id_dict = populate_xml(src_datatype, src_dataid,
-                                    xml_fp, self.gateway, repo)
+                                    xml_fp, self.gateway, repo, self.hostname)
         print(f"XML saved at {xml_fp}.")
 
         print("Starting file copy...")

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -224,18 +224,23 @@ class TransferControl(GraphControl):
         return ome, folder
 
     def _create_image_map(self, ome):
+        print("starting ome: ", ome)
         img_map = defaultdict(list)
         filelist = []
         for ann in ome.structured_annotations:
             if int(ann.id.split(":")[-1]) < 0 \
                and type(ann) == CommentAnnotation:
+                print("comment with negative ID", ann)
                 img_map[ann.value].append(int(ann.namespace.split(":")[-1]))
                 filelist.append(ann.value.split('/./')[-1])
+                print("updated filelist: ", filelist)
                 ome.structured_annotations.remove(ann)
         for i in ome.images:
+            print("checking image for ann refs: ", i.id)
             for ref in i.annotation_ref:
                 if ref.id == ann.id:
                     i.annotation_ref.remove(ref)
+                    print("new image: ", i)
         filelist = list(set(filelist))
         img_map = {x: sorted(img_map[x]) for x in img_map.keys()}
         return img_map, filelist

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -229,10 +229,12 @@ class TransferControl(GraphControl):
         img_map = defaultdict(list)
         filelist = []
         newome = copy.deepcopy(ome)
+        map_ref_ids = []
         for ann in ome.structured_annotations:
             if int(ann.id.split(":")[-1]) < 0 \
                and type(ann) == CommentAnnotation:
                 print("comment with negative ID", ann)
+                map_ref_ids.append(ann.id)
                 img_map[ann.value].append(int(ann.namespace.split(":")[-1]))
                 filelist.append(ann.value.split('/./')[-1])
                 print("updated img_map: ", img_map)
@@ -240,8 +242,8 @@ class TransferControl(GraphControl):
         for i in newome.images:
             print("checking image for ann refs: ", i.id)
             for ref in i.annotation_ref:
-                print(ref.id, ann.id)
-                if ref.id == ann.id:
+                print(ref.id, map_ref_ids)
+                if ref.id in map_ref_ids:
                     i.annotation_ref.remove(ref)
                     print("new image: ", i)
         filelist = list(set(filelist))

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -85,7 +85,7 @@ def gateway_required(func):
         self.client = self.ctx.conn(*args)
         self.gateway = BlitzGateway(client_obj=self.client)
         router = self.client.getRouter(self.client.getCommunicator())
-        self.hostname = router.split('-h ')[-1].split()[0]
+        self.hostname = str(router).split('-h ')[-1].split()[0]
         try:
             return func(self, *args, **kwargs)
         finally:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -228,7 +228,6 @@ class TransferControl(GraphControl):
         return hash, ome, folder
 
     def _create_image_map(self, ome):
-        print("starting ome: ", ome)
         img_map = defaultdict(list)
         filelist = []
         newome = copy.deepcopy(ome)

--- a/test/unit/test_set.py
+++ b/test/unit/test_set.py
@@ -52,7 +52,7 @@ class TestLoadTransferPacket():
 
     def test_src_img_map(self):
         ome = from_xml('test/data/transfer.xml')
-        src_img_map, filelist = self.transfer._create_image_map(ome)
+        _, src_img_map, filelist = self.transfer._create_image_map(ome)
         correct_map = {"/OMERO/ManagedRepository/./root_0/2022-01/14/"
                        "18-30-55.264/combined_result.tiff": [1678, 1679]}
         correct_filelist = ["root_0/2022-01/14/18-30-55.264/"


### PR DESCRIPTION
Each imported image destination-side gets a `MapAnnotation` with the following characteristics:

namespace: `openmicroscopy.org/cli/transfer`
contents:
- `origin_image_id`: ID of image on the origin server
- `origin_hostname`; hostname of original server
- `packing_timestamp`:  DD/MM/YYYY HH:MM:SS timestamp of when this annotation was generated, origin-side
- `software`: code used to generate the package (just using `omero-cli-transfer`)
- `version`: software version (retrieved from `setup.py`)
- `zip_file_md5`: md5 sum of the zip file used for transfer
