### PR TITLE
Allowing for transfer of images without `OriginalFile`s

### DIFF
--- a/.omero/docker
+++ b/.omero/docker
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -e
 set -u
 

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -183,7 +183,17 @@ def link_annotations(ome, proj_map, ds_map, img_map, ann_map, conn):
     return
 
 
+def rename_images(imgs, img_map, conn):
+    for img in imgs:
+        img_id = img_map[img.id]
+        im_obj = conn.getObject("Image", img_id)
+        im_obj.setName(img.name)
+        im_obj.save()
+    return
+
+
 def populate_omero(ome, img_map, conn, hash):
+    rename_images(ome.images, img_map, conn)
     proj_map = create_projects(ome.projects, conn)
     ds_map = create_datasets(ome.datasets, conn)
     ann_map = create_annotations(ome.structured_annotations, conn, hash)

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -223,7 +223,19 @@ def create_filepath_annotations(repo, id, conn):
     anns = []
     refs = []
     fpaths = ezomero.get_original_filepaths(conn, id)
-    for f in fpaths:
+    if fpaths:
+        for f in fpaths:
+            f = str(os.path.join(repo,  '.', f))
+            id = (-1) * uuid4().int
+            an = CommentAnnotation(id=id,
+                                   namespace=ns,
+                                   value=f
+                                   )
+            anns.append(an)
+            anref = ROIRef(id=an.id)
+            refs.append(anref)
+    else:
+        f = f'pixel_images/{id}.tiff'
         f = str(os.path.join(repo,  '.', f))
         id = (-1) * uuid4().int
         an = CommentAnnotation(id=id,

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import sys
 import os
 import copy
-from ome_types.model import CommentAnnotation
 from functools import wraps
 import shutil
 from collections import defaultdict
@@ -20,6 +19,7 @@ from hashlib import md5
 from generate_xml import populate_xml
 from generate_omero_objects import populate_omero
 
+from ome_types.model import CommentAnnotation
 from ome_types import from_xml
 from omero.sys import Parameters
 from omero.rtypes import rstring
@@ -149,13 +149,19 @@ class TransferControl(GraphControl):
     def _copy_files(self, id_list, folder, repo):
         cli = CLI()
         cli.loadplugins()
+        print(id_list)
         for id in id_list:
             path = id_list[id]
             rel_path = path.split(repo)[-1][1:]
             rel_path = str(Path(rel_path).parent)
             subfolder = str(Path(folder) / rel_path)
             os.makedirs(subfolder, mode=DIR_PERM, exist_ok=True)
-            cli.invoke(['download', id, subfolder])
+            if rel_path == "pixel_images":
+                clean_id = id.split(":")[-1]
+                filepath = str(Path(subfolder) / (clean_id + ".tiff"))
+                cli.invoke(['export', '--file', filepath, id])
+            else:
+                cli.invoke(['download', id, subfolder])
 
     def __pack(self, args):
         if isinstance(args.object, Image):


### PR DESCRIPTION
Covers the use case in #8 - images without `OriginalFile`s get exported instead of downloaded, and everything else works more or less as-is.