### PR TITLE
Enforcing whole filesets in XML files, filtering destination IDs

### DIFF
--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -381,6 +381,10 @@ def populate_image(obj, ome, conn, hostname):
     id = obj.getId()
     name = obj.getName()
     desc = obj.getDescription()
+    img_id = f"Image:{str(id)}"
+    if img_id in [i.id for i in ome.images]:
+        img_ref = ImageRef(id=img_id)
+        return img_ref
     pix = create_pixels(obj)
     img, img_ref = create_image_and_ref(id=id, name=name,
                                         description=desc, pixels=pix)
@@ -421,12 +425,12 @@ def populate_image(obj, ome, conn, hostname):
         if not roi_ref:
             continue
         img.roi_ref.append(roi_ref)
-    if img not in ome.images:
-        ome.images.append(img)
-    for fs_image in obj.getFileset().copyImages():
-        fs_img_id = f"Image:{str(fs_image.getId())}"
-        if fs_img_id not in [i.id for i in ome.images]:
-            populate_image(fs_image, ome, conn, hostname)
+    ome.images.append(img)
+    if obj.getFileset():
+        for fs_image in obj.getFileset().copyImages():
+            fs_img_id = f"Image:{str(fs_image.getId())}"
+            if fs_img_id not in [i.id for i in ome.images]:
+                populate_image(fs_image, ome, conn, hostname)
     return img_ref
 
 

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -423,6 +423,10 @@ def populate_image(obj, ome, conn, hostname):
         img.roi_ref.append(roi_ref)
     if img not in ome.images:
         ome.images.append(img)
+    for fs_image in obj.getFileset().copyImages():
+        fs_img_id = f"Image:{str(fs_image.getId())}"
+        if fs_img_id not in [i.id for i in ome.images]:
+            populate_image(fs_image, ome, conn, hostname)
     return img_ref
 
 

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -324,11 +324,12 @@ class TransferControl(GraphControl):
         dest_dict = {x: sorted(dest_dict[x]) for x in dest_dict.keys()}
         for src_k in src_dict.keys():
             src_v = src_dict[src_k]
-            dest_v = dest_dict[src_k]
-            if len(src_v) == len(dest_v):
-                for count in range(len(src_v)):
-                    map_key = f"Image:{src_v[count]}"
-                    imgmap[map_key] = dest_v[count]
+            if src_k in dest_dict.keys():
+                dest_v = dest_dict[src_k]
+                if len(src_v) == len(dest_v):
+                    for count in range(len(src_v)):
+                        map_key = f"Image:{src_v[count]}"
+                        imgmap[map_key] = dest_v[count]
         return imgmap
 
 

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -313,6 +313,8 @@ class TransferControl(GraphControl):
         for k, v in dest_map.items():
             newkey = k.split("/./")[-1]
             dest_dict[newkey].extend(v)
+        src_dict = {x: sorted(src_dict[x]) for x in src_dict.keys()}
+        dest_dict = {x: sorted(dest_dict[x]) for x in dest_dict.keys()}
         for src_k in src_dict.keys():
             src_v = src_dict[src_k]
             dest_v = dest_dict[src_k]


### PR DESCRIPTION
This PR fixes the issues reported in #12, namely:

1) Repeat imports are not an issue any longer. In addition to filtering IDs by `ClientPath` to retrieve IDs of images that were recently imported, we also filter by the existence of `MapAnnotation`s - fully-imported unpacks are annotated with provenance metadata, so previous runs of `unpack` are excluded from the list of IDs.
2) All images in a `Fileset` are added to the XML file - this avoids issues with things like packing a single image in an NDPI, or a Dataset with partial Filesets inside. Destination-side, the whole Fileset needs to be imported anyway, and any out-of-scope extra images from that import will now sit in Orphaned instead of breaking the workflow.