### PR TITLE
Extra annotations (Comments, Ratings, File Annotations)

### DIFF
--- a/.omero/py-check
+++ b/.omero/py-check
@@ -13,4 +13,4 @@ if [ -f .pre-commit-config.yaml ]; then
 else
     flake8 -v .
 fi
-rst-lint README.rst
+rst-lint README.md

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -2,10 +2,12 @@ import ezomero
 from omero.model import DatasetI
 from omero.gateway import DatasetWrapper
 from ome_types.model import TagAnnotation, MapAnnotation
+from ome_types.model import CommentAnnotation
 from ome_types.model import Line, Point, Rectangle, Ellipse, Polygon
 from ome_types.model import Polyline, Label
 from ome_types.model.simple_types import Marker
 from omero.gateway import TagAnnotationWrapper, MapAnnotationWrapper
+from omero.gateway import CommentAnnotationWrapper
 from ezomero import rois
 
 
@@ -55,6 +57,12 @@ def create_annotations(ans, conn, hash):
             map_ann.setValue(key_value_data)
             map_ann.save()
             ann_map[an.id] = map_ann.getId()
+        elif isinstance(an, CommentAnnotation):
+            comm_ann = CommentAnnotationWrapper(conn)
+            comm_ann.setValue(an.value)
+            comm_ann.setDescription(an.description)
+            comm_ann.save()
+            ann_map[an.id] = comm_ann.getId()
     return ann_map
 
 
@@ -172,6 +180,8 @@ def link_annotations(ome, proj_map, ds_map, img_map, ann_map, conn):
                 ann_obj = conn.getObject("TagAnnotation", ann_id)
             elif isinstance(ann, MapAnnotation):
                 ann_obj = conn.getObject("MapAnnotation", ann_id)
+            elif isinstance(ann, CommentAnnotation):
+                ann_obj = conn.getObject("CommentAnnotation", ann_id)
             else:
                 continue
             proj_obj.linkAnnotation(ann_obj)
@@ -186,6 +196,8 @@ def link_annotations(ome, proj_map, ds_map, img_map, ann_map, conn):
                 ann_obj = conn.getObject("TagAnnotation", ann_id)
             elif isinstance(ann, MapAnnotation):
                 ann_obj = conn.getObject("MapAnnotation", ann_id)
+            elif isinstance(ann, CommentAnnotation):
+                ann_obj = conn.getObject("CommentAnnotation", ann_id)
             else:
                 continue
             ds_obj.linkAnnotation(ann_obj)
@@ -200,6 +212,8 @@ def link_annotations(ome, proj_map, ds_map, img_map, ann_map, conn):
                 ann_obj = conn.getObject("TagAnnotation", ann_id)
             elif isinstance(ann, MapAnnotation):
                 ann_obj = conn.getObject("MapAnnotation", ann_id)
+            elif isinstance(ann, CommentAnnotation):
+                ann_obj = conn.getObject("CommentAnnotation", ann_id)
             else:
                 continue
             img_obj.linkAnnotation(ann_obj)

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -3,18 +3,20 @@ from ome_types.model import Project, ProjectRef
 from ome_types.model import Dataset, DatasetRef
 from ome_types.model import Image, ImageRef, Pixels
 from ome_types.model import TagAnnotation, MapAnnotation, ROI
+from ome_types.model import FileAnnotation, BinaryFile, BinData
 from ome_types.model import AnnotationRef, ROIRef, Map
 from ome_types.model import CommentAnnotation, LongAnnotation
 from ome_types.model import Point, Line, Rectangle, Ellipse, Polygon
 from ome_types.model import Polyline, Label
 from ome_types.model.map import M
-from omero.model import TagAnnotationI, MapAnnotationI
+from omero.model import TagAnnotationI, MapAnnotationI, FileAnnotationI
 from omero.model import CommentAnnotationI, LongAnnotationI
 from omero.model import PointI, LineI, RectangleI, EllipseI, PolygonI
 from omero.model import PolylineI, LabelI
 import pkg_resources
 import ezomero
 import os
+import base64
 from uuid import uuid4
 from datetime import datetime
 from pathlib import Path
@@ -82,6 +84,12 @@ def create_roi_and_ref(**kwargs):
     roi = ROI(**kwargs)
     roiref = ROIRef(id=roi.id)
     return roi, roiref
+
+
+def create_file_ann_and_ref(**kwargs):
+    file_ann = FileAnnotation(**kwargs)
+    file_ann_ref = AnnotationRef(id=file_ann.id)
+    return file_ann, file_ann_ref
 
 
 def create_point(shape):
@@ -293,32 +301,45 @@ def create_shapes(roi):
     return shapes
 
 
-def create_filepath_annotations(id, conn):
-    ns = f'Image:{id}'
+def create_filepath_annotations(id, conn, filename=None):
+    ns = id
     anns = []
     refs = []
-    fpaths = ezomero.get_original_filepaths(conn, id)
-    if len(fpaths) > 1:
-        allpaths = []
-        for f in fpaths:
-            f = Path(f)
-            allpaths.append(f.parts)
-        common_root = Path(*os.path.commonprefix(allpaths))
-        path = os.path.join(common_root, 'mock_folder')
-        id = (-1) * uuid4().int
-        an = CommentAnnotation(id=id,
-                               namespace=ns,
-                               value=str(path)
-                               )
-        anns.append(an)
-        anref = ROIRef(id=an.id)
-        refs.append(anref)
-    else:
-        if fpaths:
-            f = fpaths[0]
+    fp_type = ns.split(":")[0]
+    clean_id = int(ns.split(":")[-1])
+    if fp_type == "Image":
+        fpaths = ezomero.get_original_filepaths(conn, clean_id)
+        if len(fpaths) > 1:
+            allpaths = []
+            for f in fpaths:
+                f = Path(f)
+                allpaths.append(f.parts)
+            common_root = Path(*os.path.commonprefix(allpaths))
+            path = os.path.join(common_root, 'mock_folder')
+            id = (-1) * uuid4().int
+            an = CommentAnnotation(id=id,
+                                   namespace=ns,
+                                   value=str(path)
+                                   )
+            anns.append(an)
+            anref = ROIRef(id=an.id)
+            refs.append(anref)
         else:
-            f = f'pixel_images/{id}.tiff'
+            if fpaths:
+                f = fpaths[0]
+            else:
+                f = f'pixel_images/{clean_id}.tiff'
 
+            id = (-1) * uuid4().int
+            an = CommentAnnotation(id=id,
+                                   namespace=ns,
+                                   value=f
+                                   )
+            anns.append(an)
+            anref = ROIRef(id=an.id)
+            refs.append(anref)
+    elif fp_type == "Annotation":
+        f = f'file_annotations/{clean_id}/{filename}'
         id = (-1) * uuid4().int
         an = CommentAnnotation(id=id,
                                namespace=ns,
@@ -351,7 +372,7 @@ def create_provenance_metadata(id, hostname):
     return kv, ref
 
 
-def populate_roi(obj, roi_obj, ome):
+def populate_roi(obj, roi_obj, ome, conn):
     id = obj.getId().getValue()
     name = obj.getName()
     if name is not None:
@@ -365,7 +386,7 @@ def populate_roi(obj, roi_obj, ome):
     roi, roi_ref = create_roi_and_ref(id=id, name=name, description=desc,
                                       union=shapes)
     for ann in roi_obj.listAnnotations():
-        add_annotation(roi, ann, ome)
+        add_annotation(roi, ann, ome, conn)
     if roi not in ome.rois:
         ome.rois.append(roi)
     return roi_ref
@@ -383,14 +404,14 @@ def populate_image(obj, ome, conn, hostname):
     img, img_ref = create_image_and_ref(id=id, name=name,
                                         description=desc, pixels=pix)
     for ann in obj.listAnnotations():
-        add_annotation(img, ann, ome)
+        add_annotation(img, ann, ome, conn)
 
     kv, ref = create_provenance_metadata(id, hostname)
     kv_id = f"Annotation:{str(kv.id)}"
     if kv_id not in [i.id for i in ome.structured_annotations]:
         ome.structured_annotations.append(kv)
     img.annotation_ref.append(ref)
-    filepath_anns, refs = create_filepath_annotations(id, conn)
+    filepath_anns, refs = create_filepath_annotations(img_id, conn)
     for i in range(len(filepath_anns)):
         ome.structured_annotations.append(filepath_anns[i])
         img.annotation_ref.append(refs[i])
@@ -398,7 +419,7 @@ def populate_image(obj, ome, conn, hostname):
     rois = roi_service.findByImage(id, None).rois
     for roi in rois:
         roi_obj = conn.getObject('Roi', roi.getId().getValue())
-        roi_ref = populate_roi(roi, roi_obj, ome)
+        roi_ref = populate_roi(roi, roi_obj, ome, conn)
         if not roi_ref:
             continue
         img.roi_ref.append(roi_ref)
@@ -420,7 +441,7 @@ def populate_dataset(obj, ome, conn, hostname):
     ds, ds_ref = create_dataset_and_ref(id=id, name=name,
                                         description=desc)
     for ann in obj.listAnnotations():
-        add_annotation(ds, ann, ome)
+        add_annotation(ds, ann, ome, conn)
     for img in obj.listChildren():
         img_obj = conn.getObject('Image', img.getId())
         img_ref = populate_image(img_obj, ome, conn, hostname)
@@ -437,7 +458,7 @@ def populate_project(obj, ome, conn, hostname):
     desc = obj.getDescription()
     proj, _ = create_proj_and_ref(id=id, name=name, description=desc)
     for ann in obj.listAnnotations():
-        add_annotation(proj, ann, ome)
+        add_annotation(proj, ann, ome, conn)
     for ds in obj.listChildren():
         ds_obj = conn.getObject('Dataset', ds.getId())
         ds_ref = populate_dataset(ds_obj, ome, conn, hostname)
@@ -445,7 +466,7 @@ def populate_project(obj, ome, conn, hostname):
     ome.projects.append(proj)
 
 
-def add_annotation(obj, ann, ome):
+def add_annotation(obj, ann, ome, conn):
     if ann.OMERO_TYPE == TagAnnotationI:
         tag, ref = create_tag_and_ref(id=ann.getId(),
                                       value=ann.getTextValue())
@@ -483,13 +504,40 @@ def add_annotation(obj, ann, ome):
             ome.structured_annotations.append(long)
         obj.annotation_ref.append(ref)
 
+    elif ann.OMERO_TYPE == FileAnnotationI:
+        contents = ann.getFile().getPath().encode()
+        b64 = base64.b64encode(contents)
+        length = len(b64)
+        binaryfile = BinaryFile(file_name=ann.getFile().getPath(),
+                                size=ann.getFile().getSize(),
+                                bin_data=BinData(big_endian=True,
+                                                 length=length,
+                                                 value=b64
+                                                 )
+                                )
+        long, ref = create_file_ann_and_ref(id=ann.getId(),
+                                            namespace=ann.getNs(),
+                                            binary_file=binaryfile)
+        filepath_anns, refs = create_filepath_annotations(
+                                long.id,
+                                conn,
+                                filename=ann.getFile().getPath())
+        for i in range(len(filepath_anns)):
+            ome.structured_annotations.append(filepath_anns[i])
+            long.annotation_ref.append(refs[i])
+        if long.id not in [i.id for i in ome.structured_annotations]:
+            ome.structured_annotations.append(long)
+        obj.annotation_ref.append(ref)
 
-def list_image_ids(ome):
+
+def list_file_ids(ome):
     id_list = {}
     for ann in ome.structured_annotations:
+        print(ann)
         clean_id = int(ann.id.split(":")[-1])
         if isinstance(ann, CommentAnnotation) and clean_id < 0:
             id_list[ann.namespace] = ann.value
+            print(id_list)
     return id_list
 
 
@@ -505,5 +553,5 @@ def populate_xml(datatype, id, filepath, conn, hostname):
     with open(filepath, 'w') as fp:
         print(to_xml(ome), file=fp)
         fp.close()
-    path_id_dict = list_image_ids(ome)
+    path_id_dict = list_file_ids(ome)
     return path_id_dict

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -4,12 +4,12 @@ from ome_types.model import Dataset, DatasetRef
 from ome_types.model import Image, ImageRef, Pixels
 from ome_types.model import TagAnnotation, MapAnnotation, ROI
 from ome_types.model import AnnotationRef, ROIRef, Map
-from ome_types.model import CommentAnnotation
+from ome_types.model import CommentAnnotation, LongAnnotation
 from ome_types.model import Point, Line, Rectangle, Ellipse, Polygon
 from ome_types.model import Polyline, Label
 from ome_types.model.map import M
 from omero.model import TagAnnotationI, MapAnnotationI
-from omero.model import CommentAnnotationI
+from omero.model import CommentAnnotationI, LongAnnotationI
 from omero.model import PointI, LineI, RectangleI, EllipseI, PolygonI
 from omero.model import PolylineI, LabelI
 import pkg_resources
@@ -70,6 +70,12 @@ def create_kv_and_ref(**kwargs):
     kv = MapAnnotation(**kwargs)
     kvref = AnnotationRef(id=kv.id)
     return kv, kvref
+
+
+def create_long_and_ref(**kwargs):
+    long = LongAnnotation(**kwargs)
+    longref = AnnotationRef(id=long.id)
+    return long, longref
 
 
 def create_roi_and_ref(**kwargs):
@@ -467,6 +473,14 @@ def add_annotation(obj, ann, ome):
                                         value=ann.getTextValue())
         if comm.id not in [i.id for i in ome.structured_annotations]:
             ome.structured_annotations.append(comm)
+        obj.annotation_ref.append(ref)
+
+    elif ann.OMERO_TYPE == LongAnnotationI:
+        long, ref = create_long_and_ref(id=ann.getId(),
+                                        namespace=ann.getNs(),
+                                        value=ann.getValue())
+        if long.id not in [i.id for i in ome.structured_annotations]:
+            ome.structured_annotations.append(long)
         obj.annotation_ref.append(ref)
 
 


### PR DESCRIPTION
This PR adds `CommentAnnotation`s, `LongAnnotation`s and `FileAnnotation`s. Since we're already using `CommentAnnotation`s to keep track of file locations for `Image`s, we also use the same for `FileAnnotation`s, with some extra logic to accommodate `omero download`'s different behavior between Filesets and OriginalFiles. There is no clash between these `CommentAnnotation`s and real ones, since these use negative unique IDs.

Current commit seems to do all of these correctly on local testing, but I will probably throw a few more cases at it next week before feeling good about a merge. 